### PR TITLE
Mutate an empty node ID into Kyverno managed bootstrap config

### DIFF
--- a/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
+++ b/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
@@ -28,9 +28,9 @@ spec:
             - (name): "*"
               env:
               - name: GRPC_XDS_BOOTSTRAP_CONFIG
-                value: '{"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}]}'
+                value: '{"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}], "node":{"id":"", "locality":{}}}'
           containers:
             - (name): "*"
               env:
               - name: GRPC_XDS_BOOTSTRAP_CONFIG
-                value: '{"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}]}'
+                value: '{"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}], "node":{"id":"", "locality":{}}}'


### PR DESCRIPTION
Things like nodeJS client will moan if "node" is omitted from the bootstrap config. Mutate it to an empty string should be safe, since our snapshotter is using a dummy empty id for snaps.