### PR TITLE
Backoff retry when starting remote watchers

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,0 +1,101 @@
+// Package backoff includes this backoff function copied from:
+// https://github.com/jpillora/backoff/blob/d80867952dff4e2fbfb4280ded4ff94d67790457/backoff.go
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+// Backoff is a time.Duration counter, starting at Min. After every call to
+// the Duration method the current timing is multiplied by Factor, but it
+// never exceeds Max.
+//
+// Backoff is not generally concurrent-safe, but the ForAttempt method can
+// be used concurrently.
+type Backoff struct {
+	attempt uint64
+	// Factor is the multiplying factor for each increment step
+	Factor float64
+	// Jitter eases contention by randomizing backoff steps
+	Jitter bool
+	// Min and Max are the minimum and maximum values of the counter
+	Min, Max time.Duration
+}
+
+// Duration returns the duration for the current attempt before incrementing
+// the attempt counter. See ForAttempt.
+func (b *Backoff) Duration() time.Duration {
+	d := b.ForAttempt(float64(atomic.AddUint64(&b.attempt, 1) - 1))
+	return d
+}
+
+const maxInt64 = float64(math.MaxInt64 - 512)
+
+// ForAttempt returns the duration for a specific attempt. This is useful if
+// you have a large number of independent Backoffs, but don't want use
+// unnecessary memory storing the Backoff parameters per Backoff. The first
+// attempt should be 0.
+//
+// ForAttempt is concurrent-safe.
+func (b *Backoff) ForAttempt(attempt float64) time.Duration {
+	// Zero-values are nonsensical, so we use
+	// them to apply defaults
+	min := b.Min
+	if min <= 0 {
+		min = 100 * time.Millisecond
+	}
+	max := b.Max
+	if max <= 0 {
+		max = 10 * time.Second
+	}
+	if min >= max {
+		// short-circuit
+		return max
+	}
+	factor := b.Factor
+	if factor <= 0 {
+		factor = 2
+	}
+	//calculate this duration
+	minf := float64(min)
+	durf := minf * math.Pow(factor, attempt)
+	if b.Jitter {
+		durf = rand.Float64()*(durf-minf) + minf
+	}
+	//ensure float64 wont overflow int64
+	if durf > maxInt64 {
+		return max
+	}
+	dur := time.Duration(durf)
+	//keep within bounds
+	if dur < min {
+		return min
+	}
+	if dur > max {
+		return max
+	}
+	return dur
+}
+
+// Reset restarts the current attempt counter at zero.
+func (b *Backoff) Reset() {
+	atomic.StoreUint64(&b.attempt, 0)
+}
+
+// Attempt returns the current attempt counter value.
+func (b *Backoff) Attempt() float64 {
+	return float64(atomic.LoadUint64(&b.attempt))
+}
+
+// Copy returns a backoff with equals constraints as the original
+func (b *Backoff) Copy() *Backoff {
+	return &Backoff{
+		Factor: b.Factor,
+		Jitter: b.Jitter,
+		Min:    b.Min,
+		Max:    b.Max,
+	}
+}

--- a/backoff/retry.go
+++ b/backoff/retry.go
@@ -1,0 +1,45 @@
+package backoff
+
+import (
+	"time"
+
+	"github.com/utilitywarehouse/semaphore-xds/log"
+	"github.com/utilitywarehouse/semaphore-xds/queue"
+)
+
+type watchOperation func(*queue.Queue, <-chan struct{}) error
+
+const (
+	defaultBackoffJitter = true
+	defaultBackoffMin    = 2 * time.Second
+	defaultBackoffMax    = 1 * time.Minute
+)
+
+// Retry will use the default backoff values to retry the passed operation
+func RetryWatch(op watchOperation, Q *queue.Queue, stopCh <-chan struct{}, description string) {
+	b := &Backoff{
+		Jitter: defaultBackoffJitter,
+		Min:    defaultBackoffMin,
+		Max:    defaultBackoffMax,
+	}
+	RetryWithBackoff(op, Q, stopCh, b, description)
+}
+
+// RetryWithBackoff will retry the passed function (operation) using the given
+// backoff
+func RetryWithBackoff(op watchOperation, Q *queue.Queue, stopCh <-chan struct{}, b *Backoff, description string) {
+	b.Reset()
+	for {
+		err := op(Q, stopCh)
+		if err == nil {
+			return
+		}
+		d := b.Duration()
+		log.Logger.Error("Retry failed",
+			"description", description,
+			"error", err,
+			"backoff", d,
+		)
+		time.Sleep(d)
+	}
+}

--- a/backoff/retry_test.go
+++ b/backoff/retry_test.go
@@ -1,0 +1,42 @@
+package backoff
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/utilitywarehouse/semaphore-xds/log"
+	"github.com/utilitywarehouse/semaphore-xds/queue"
+)
+
+var testFuncCallCounter int
+var successThreshold int
+
+func testFunc(*queue.Queue, <-chan struct{}) error {
+	testFuncCallCounter++
+
+	if testFuncCallCounter >= successThreshold {
+		return nil
+	}
+	return errors.New("error")
+
+}
+
+func TestRetryWithBackoff(t *testing.T) {
+	log.InitLogger("retry-test", "info")
+	b := &Backoff{
+		Jitter: false,
+		Min:    10 * time.Millisecond,
+		Max:    1 * time.Second,
+	}
+	successThreshold = 3
+
+	// Retrying testFunc should fail 2 times before hitting the success
+	// threshold
+	var q *queue.Queue
+	stopCh := make(chan struct{})
+	RetryWithBackoff(testFunc, q, stopCh, b, "test func")
+	assert.Equal(t, testFuncCallCounter, 3)            // should be 3 after 2 consecutive fails
+	assert.Equal(t, b.Duration(), 40*time.Millisecond) // should be 40 millisec after failing for 10 and 20 and without a jitter
+}


### PR DESCRIPTION
When a remote cluster's resources cannot be watched, the controller should not block. This allows the controller to run while retrying to start all remote watchers.