### PR TITLE
Fix priorities when local EndpointSlices have 0 Endpoints

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -224,8 +224,10 @@ func (c *Controller) endpointsStoreForXdsServiceStore(svcs xds.XdsServiceStore) 
 		}
 		foundLocalEndpoints := false
 		for _, e := range es {
-			store.Add(s.Service.Name, s.Service.Namespace, e, uint32(0)) // default 0 priority for all local endpoints
-			foundLocalEndpoints = true
+			if e.Endpoints != nil && len(e.Endpoints) > 0 {
+				store.Add(s.Service.Name, s.Service.Namespace, e, uint32(0)) // default 0 priority for all local endpoints
+				foundLocalEndpoints = true
+			}
 		}
 		// Add EndpointSlices from remote clusters if allowed
 		if s.AllowRemoteEndpoints {

--- a/controller/test-resources/endpointslice-empty.yaml
+++ b/controller/test-resources/endpointslice-empty.yaml
@@ -1,0 +1,17 @@
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  generateName: grpc-echo-server-
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: grpc-echo-server
+  name: grpc-echo-server-8mwr4
+  namespace: labs
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Service
+    name: grpc-echo-server
+ports: null


### PR DESCRIPTION
If a service is scaled down to 0 pods, the respective EndpointSlices are not removed, but do not contain any Endpoints. In this case we need to identify that there are no active Endpoints and avoid attempting to give higher priority to local addresses.