### PR TITLE
Handle scenarios where EndpointSlices are missing Zone

### DIFF
--- a/xds/endpoints.go
+++ b/xds/endpoints.go
@@ -167,11 +167,18 @@ func endpointSliceToClusterEndpoints(e *discoveryv1.EndpointSlice, priority uint
 	ceps := []EdsClusterEndpoints{}
 	for _, p := range e.Ports {
 		for _, ep := range e.Endpoints {
+			// In case there is no zone specified we should add a dummy value and still register the
+			// endpoint and serve it to clients. Then we can rely on an alert which checks the zone
+			// since this might affect routing algorithms.
+			zone := "none"
+			if ep.Zone != nil {
+				zone = *ep.Zone
+			}
 			ceps = append(ceps, EdsClusterEndpoints{
 				addresses: ep.Addresses,
 				port:      *p.Port,
 				priority:  priority,
-				zone:      *ep.Zone,
+				zone:      zone,
 				subzone:   ep.TargetRef.Name, // This should be the respective pod name, hacky way to have separate localities per endpoint.
 				healthy:   *ep.Conditions.Ready,
 			})


### PR DESCRIPTION
We saw a case where the xds servers were spinning because an EndpointSlice/Address did not specify a Zone. We should still be able to serve those endpoints to clients and create an alert to manually check things.
Kube-controller-manager is responsible for populating the zone in EndpointSlices.
We set the value to "none". This will not affect existing routing algorithms but should be taken into account if we implement zone specific routing strategies in the future.