### PR TITLE
Add a MaxConnectionIdle to xDS server

### DIFF
--- a/xds/snapshotter.go
+++ b/xds/snapshotter.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
@@ -232,7 +233,10 @@ func (s *Snapshotter) ListenAndServe() {
 	ctx := context.Background()
 
 	xdsServer := xds.NewServer(ctx, &s.muxCache, s)
-	grpcOptions := []grpc.ServerOption{grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams)}
+	grpcOptions := []grpc.ServerOption{
+		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
+		grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionIdle: 30 * time.Minute}),
+	}
 	grpcServer := grpc.NewServer(grpcOptions...)
 	registerServices(grpcServer, xdsServer)
 	runGrpcServer(ctx, grpcServer, s.servePort)


### PR DESCRIPTION
Since an idle_timeout was introduced by default in the client: https://github.com/grpc/grpc-go/pull/6585/files we are observing clients closing watches on xds resources after 30 minutes and when they are trying to wake from IDLE state are not receiving proper updates from the server. Most likely client and server are on different state where the server does not think it should provide any update while the client has offloaded all the Resolver resources and needs a complete LDS update (at least). MaxConnectionIdle should force the server to send a `GoAway` after 30 minutes and trigger the connection to be re-established if needed.