### PR TITLE
Support multiple nodes by id to register to the server

### DIFF
--- a/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
+++ b/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
@@ -27,10 +27,20 @@ spec:
           initContainers:
             - (name): "*"
               env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
               - name: GRPC_XDS_BOOTSTRAP_CONFIG
-                value: '{"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}], "node":{"id":"", "locality":{}}}'
+                value: >-
+                  {"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}], "node":{"id":"\$(POD_NAME)", "locality":{}}}
           containers:
             - (name): "*"
               env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
               - name: GRPC_XDS_BOOTSTRAP_CONFIG
-                value: '{"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}], "node":{"id":"", "locality":{}}}'
+                value: >- 
+                  {"xds_servers": [{"server_uri": "semaphore-xds.sys-semaphore.svc.cluster.local:18000", "channel_creds": [{"type": "insecure"}], "server_features": ["xds_v3"]}], "node":{"id":"\$(POD_NAME)", "locality":{}}}

--- a/xds/snapshotter.go
+++ b/xds/snapshotter.go
@@ -350,7 +350,14 @@ func (s *Snapshotter) getResourcesFromCache(typeURL string, resources []string) 
 	for _, name := range resources {
 		r, ok := fullResources[name]
 		if !ok {
-			return res, fmt.Errorf("Requested resource: %s of type: %s not found", name, typeURL)
+			// If a resource is not found, do not fail, which will result in closing the stream.
+			// Instead log an warning and keep populating the resources list
+			log.Logger.Warn(
+				"Requested resource not found",
+				"name", name,
+				"type", typeURL,
+			)
+			continue
 		}
 		res = append(res, r)
 	}

--- a/xds/snapshotter_test.go
+++ b/xds/snapshotter_test.go
@@ -239,3 +239,125 @@ func TestSnapEndpoints_UpdateAddress(t *testing.T) {
 		assert.Equal(t, uint32(1), eds.Endpoints[0].Priority)
 	}
 }
+
+func TestSnapServices_NodeSnapshotResources(t *testing.T) {
+	snapshotter := NewSnapshotter(uint(0), float64(0), float64(0))
+	serviceStore := NewXdsServiceStore()
+	// fooA.bar:80
+	svcA := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fooA",
+			Namespace: "bar",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				v1.ServicePort{
+					Name: "test",
+					Port: int32(80),
+				}},
+		},
+	}
+	serviceStore.AddOrUpdate(svcA, Service{
+		Policy:                   clusterv3.Cluster_ROUND_ROBIN,
+		EnableRemoteEndpoints:    false,
+		PrioritizeLocalEndpoints: false,
+	})
+	// fooB.bar:80
+	svcB := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fooB",
+			Namespace: "bar",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				v1.ServicePort{
+					Name: "test",
+					Port: int32(80),
+				}},
+		},
+	}
+	serviceStore.AddOrUpdate(svcB, Service{
+		Policy:                   clusterv3.Cluster_ROUND_ROBIN,
+		EnableRemoteEndpoints:    false,
+		PrioritizeLocalEndpoints: false,
+	})
+	// Snap to add services to the default snapshot
+	snapshotter.SnapServices(serviceStore)
+
+	// Add a new test node
+	nodeID := "test-node"
+	snapshotter.addNewNode(nodeID)
+	// Request all listener resources for the node - Update the node snapshot
+	assert.Equal(t, true, snapshotter.needToUpdateSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80", "fooB.bar:80"}))
+	if err := snapshotter.updateNodeSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80", "fooB.bar:80"}); err != nil {
+		t.Fatal(err)
+	}
+	// Verify Listener resources are now in a snaphot for the node id
+	snap, err := snapshotter.servicesCache.GetSnapshot(nodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(snap.GetResources(resource.ListenerType)))
+	assert.Equal(t, 0, len(snap.GetResources(resource.ClusterType)))
+	assert.Equal(t, 0, len(snap.GetResources(resource.RouteType)))
+	// A new ADS request with fewer resources should remove from snapshot
+	assert.Equal(t, true, snapshotter.needToUpdateSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80"}))
+	if err := snapshotter.updateNodeSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80"}); err != nil {
+		t.Fatal(err)
+	}
+	// Verify Listener resources are now in a snaphot for the node id
+	snap, err = snapshotter.servicesCache.GetSnapshot(nodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(snap.GetResources(resource.ListenerType)))
+	assert.Equal(t, 0, len(snap.GetResources(resource.ClusterType)))
+	assert.Equal(t, 0, len(snap.GetResources(resource.RouteType)))
+	// A full snap should not bring more resources in the node snapshot
+	snapshotter.SnapServices(serviceStore)
+	snap, err = snapshotter.servicesCache.GetSnapshot(nodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(snap.GetResources(resource.ListenerType)))
+	assert.Equal(t, 0, len(snap.GetResources(resource.ClusterType)))
+	assert.Equal(t, 0, len(snap.GetResources(resource.RouteType)))
+	// EmptyNodeID snapshot contains the full map of resources
+	snap, err = snapshotter.servicesCache.GetSnapshot(EmptyNodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(snap.GetResources(resource.ListenerType)))
+	assert.Equal(t, 2, len(snap.GetResources(resource.ClusterType)))
+	assert.Equal(t, 2, len(snap.GetResources(resource.RouteType)))
+	// Client requesting more resources again should bring them back into the node snapshot
+	assert.Equal(t, true, snapshotter.needToUpdateSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80", "fooB.bar:80"}))
+	if err := snapshotter.updateNodeSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80", "fooB.bar:80"}); err != nil {
+		t.Fatal(err)
+	}
+	snap, err = snapshotter.servicesCache.GetSnapshot(nodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(snap.GetResources(resource.ListenerType)))
+	// Requesting non existing resources should leave the list unaffected
+	assert.Equal(t, true, snapshotter.needToUpdateSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80", "fooB.bar:80", "fooC.bar:80"}))
+	if err := snapshotter.updateNodeSnapshot(nodeID, resource.ListenerType, []string{"fooA.bar:80", "fooB.bar:80", "fooC.bar:80"}); err != nil {
+		t.Fatal(err)
+	}
+	snap, err = snapshotter.servicesCache.GetSnapshot(nodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(snap.GetResources(resource.ListenerType)))
+	// Requesting an empty list of resources package
+	assert.Equal(t, true, snapshotter.needToUpdateSnapshot(nodeID, resource.ListenerType, []string{""}))
+	if err := snapshotter.updateNodeSnapshot(nodeID, resource.ListenerType, []string{""}); err != nil {
+		t.Fatal(err)
+	}
+	snap, err = snapshotter.servicesCache.GetSnapshot(nodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 0, len(snap.GetResources(resource.ListenerType)))
+}

--- a/xds/utils.go
+++ b/xds/utils.go
@@ -23,10 +23,6 @@ import (
 	xdsTypes "github.com/utilitywarehouse/semaphore-xds/types"
 )
 
-const (
-	EmptyNodeID = ""
-)
-
 func makeClusterName(name, namespace string, port int32) string {
 	//return net.JoinHostPort(fmt.Sprintf("%s.%s", name, namespace), strconv.Itoa(int(port)))
 	return fmt.Sprintf("%s.%s.%s", name, namespace, strconv.Itoa(int(port)))
@@ -248,4 +244,24 @@ func ParseRetryBackOff(base, max string) *routev3.RetryPolicy_RetryBackOff {
 		BaseInterval: durationpb.New(baseDuration),
 		MaxInterval:  durationpb.New(maxDuration),
 	}
+}
+
+// resourcesMatch checks if 2 slices contain the same set of resources
+func resourcesMatch(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, e := range b {
+		inSlice := false
+		for _, r := range a {
+			if e == r {
+				inSlice = true
+				break
+			}
+		}
+		if !inSlice {
+			return false
+		}
+	}
+	return true
 }

--- a/xds/utils_test.go
+++ b/xds/utils_test.go
@@ -1,17 +1,16 @@
-package xds_test
+package xds
 
 import (
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/utilitywarehouse/semaphore-xds/xds"
 )
 
 func TestParseRetryOn(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		assert.Equal(t, "", xds.ParseRetryOn([]string{}))
-		assert.Equal(t, "", xds.ParseRetryOn([]string{""}))
+		assert.Equal(t, "", ParseRetryOn([]string{}))
+		assert.Equal(t, "", ParseRetryOn([]string{""}))
 	})
 
 	t.Run("single", func(t *testing.T) {
@@ -24,12 +23,12 @@ func TestParseRetryOn(t *testing.T) {
 		}
 
 		for _, v := range valid {
-			assert.Equal(t, v, xds.ParseRetryOn([]string{v}))
+			assert.Equal(t, v, ParseRetryOn([]string{v}))
 		}
 	})
 
 	t.Run("mixed", func(t *testing.T) {
-		assert.Equal(t, "some,internal,eggs,cancelled,unavailable", xds.ParseRetryOn([]string{
+		assert.Equal(t, "some,internal,eggs,cancelled,unavailable", ParseRetryOn([]string{
 			"some",
 			"internal",
 			"  eggs",
@@ -41,44 +40,65 @@ func TestParseRetryOn(t *testing.T) {
 
 func TestParseNumRetries(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		assert.Equal(t, uint32(1), xds.ParseNumRetries(nil).Value)
+		assert.Equal(t, uint32(1), ParseNumRetries(nil).Value)
 	})
 
 	t.Run("valid", func(t *testing.T) {
 		var zero uint32 = 0
-		assert.Equal(t, uint32(0), xds.ParseNumRetries(&zero).Value)
+		assert.Equal(t, uint32(0), ParseNumRetries(&zero).Value)
 
 		var five uint32 = 5
-		assert.Equal(t, uint32(5), xds.ParseNumRetries(&five).Value)
+		assert.Equal(t, uint32(5), ParseNumRetries(&five).Value)
 	})
 }
 
 func TestParseRetryBackOff(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
-		policy := xds.ParseRetryBackOff("", "")
+		policy := ParseRetryBackOff("", "")
 
 		assert.Equal(t, 25*time.Millisecond, policy.BaseInterval.AsDuration())
 		assert.Equal(t, 250*time.Millisecond, policy.MaxInterval.AsDuration())
 	})
 
 	t.Run("max default uses base", func(t *testing.T) {
-		policy := xds.ParseRetryBackOff("17ms", "")
+		policy := ParseRetryBackOff("17ms", "")
 
 		assert.Equal(t, 17*time.Millisecond, policy.BaseInterval.AsDuration())
 		assert.Equal(t, 170*time.Millisecond, policy.MaxInterval.AsDuration())
 	})
 
 	t.Run("both set", func(t *testing.T) {
-		policy := xds.ParseRetryBackOff("9ms", "77ms")
+		policy := ParseRetryBackOff("9ms", "77ms")
 
 		assert.Equal(t, 9*time.Millisecond, policy.BaseInterval.AsDuration())
 		assert.Equal(t, 77*time.Millisecond, policy.MaxInterval.AsDuration())
 	})
 
 	t.Run("max not less than base", func(t *testing.T) {
-		policy := xds.ParseRetryBackOff("10ms", "7ms")
+		policy := ParseRetryBackOff("10ms", "7ms")
 
 		assert.Equal(t, 10*time.Millisecond, policy.BaseInterval.AsDuration())
 		assert.Equal(t, 10*time.Millisecond, policy.MaxInterval.AsDuration())
 	})
+}
+
+func TestResourcesMatch(t *testing.T) {
+	// empty lists
+	a := []string{}
+	b := []string{}
+	assert.Equal(t, true, resourcesMatch(a, b))
+	// length mismatch
+	b = []string{"1"}
+	c := []string{"1", "2"}
+	assert.Equal(t, false, resourcesMatch(a, b))
+	assert.Equal(t, false, resourcesMatch(a, c))
+	// different sets
+	a = []string{"1", "2"}
+	b = []string{"2", "3"}
+	assert.Equal(t, false, resourcesMatch(a, b))
+	// same sets
+	b = []string{"1", "2"}
+	assert.Equal(t, true, resourcesMatch(a, b))
+	// same sets, mixed values
+	b = []string{"2", "1"}
 }


### PR DESCRIPTION
Adds support for dedicated snapshots per node based on id. A client
should set its node id on requests to the server. Based on the requested
resources, the server should adjust the snapshot and add or remove
resources accordingly. That way the server can keep an up to date map of
resources known to clients and respect clients features like idle
timeout.
We keep using an empty node id snapshot as the source of truth to
initialise new nodes or serve nodes that request without any node id
set (legacy clients).