### PR TITLE
Lower log level for legacy clients requests

### DIFF
--- a/xds/snapshotter.go
+++ b/xds/snapshotter.go
@@ -255,7 +255,7 @@ func (s *Snapshotter) OnStreamRequest(id int64, r *discovery.DiscoveryRequest) e
 	}
 	// Legacy empty nodeID client
 	if r.GetNode().GetId() == EmptyNodeID {
-		log.Logger.Warn("Client using empty string as node id", "client", stream.peerAddress)
+		log.Logger.Info("Client using empty string as node id", "client", stream.peerAddress)
 		return nil
 	}
 


### PR DESCRIPTION
It's not really a warning and can get really chatty on requests influx