### PR TITLE
Make locality lowercase in injected bootrap config

### DIFF
--- a/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
+++ b/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
@@ -41,7 +41,7 @@ spec:
                     ],
                     "node":{
                       "id":"{{request.object.metadata.namespace}}/\$(POD_NAME)",
-                      "Locality":{}}
+                      "locality":{}}
                   }
           containers:
             - (name): "*"
@@ -60,5 +60,5 @@ spec:
                     ],
                     "node":{
                       "id":"{{request.object.metadata.namespace}}/\$(POD_NAME)",
-                      "Locality":{}}
+                      "locality":{}}
                   }


### PR DESCRIPTION
Clients such as JS can not handle this in a case-insensitve manner leading to an error trying to bootstrap xDS