### PR TITLE
Mutate pods only on CREATE operations

### DIFF
--- a/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
+++ b/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
@@ -19,6 +19,8 @@ spec:
       resources:
         kinds:
         - Pod
+        operations:
+        - CREATE
         selector:
           matchLabels:
             xds.semaphore.uw.systems/client: "true"


### PR DESCRIPTION
That should be the correct way to do it, since patching environment variables is not allow during UPDATE operations and we should not care about DELETE. The following error will surface when trying to patch the xds bootstrap config after creation:
```
pod updates may not change fields other than `spec.containers[*].image`,
`spec.initContainers[*].image`,`spec.activeDeadlineSeconds`,`spec.tolerations`
(only additions to existing tolerations),`spec.terminationGracePeriodSeconds`
(allow it to be set to 1 if it was previously negative)
```