### PR TITLE
Inject xDS bootstrap environment variable to all pods by default

### DIFF
--- a/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
+++ b/deploy/kustomize/kyverno/mutate/mutate-semaphore-xds-clients-env.yaml
@@ -22,17 +22,20 @@ spec:
                 - Pod
               operations:
                 - CREATE
-              selector:
-                matchLabels:
-                  xds.semaphore.uw.systems/client: "true"
+      exclude:
+        any:
           - resources:
               kinds:
                 - Pod
-              operations:
-                - CREATE
               selector:
                 matchLabels:
-                  xds.semaphore.uw.systems/client: "native"
+                  xds.semaphore.uw.systems/client: "exclude"
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  xds.semaphore.uw.systems/client: "envoy-sidecar"
       mutate:
         patchStrategicMerge:
           spec:


### PR DESCRIPTION
This will inject the environment variable everywhere unless we explicitly specify a label to exclude it or using an envoy sidecar setup