### PR TITLE
Fix EDS resource names for federation setups

### DIFF
--- a/xds/endpoints.go
+++ b/xds/endpoints.go
@@ -196,7 +196,7 @@ func createClustersFromEndpointStore(store XdsEndpointStore, authority string) E
 			for _, ce := range endpointSliceToClusterEndpoints(e.endpointSlice, e.priority) {
 				clusterName := makeClusterName(serviceEndpoint.service, serviceEndpoint.namespace, ce.port)
 				if authority != "" {
-					clusterName = makeXdstpClusterName(serviceEndpoint.service, serviceEndpoint.namespace, authority, ce.port)
+					clusterName = makeXdstpClusterLoadAssignmentName(serviceEndpoint.service, serviceEndpoint.namespace, authority, ce.port)
 				}
 				if c, ok := clusters[clusterName]; !ok {
 					clusters[clusterName] = EdsCluster{

--- a/xds/service.go
+++ b/xds/service.go
@@ -196,9 +196,7 @@ func makeCluster(name, namespace, authority string, port int32, policy clusterv3
 
 	cluster := cluster(clusterName, policy)
 	if authority != "" {
-		// This will be the name of the subsequently requested ClusterLoadAssignment. We need to set this
-		// to the cluster name to hit resources in the cache and reply to EDS requests
-		cluster.EdsClusterConfig.ServiceName = clusterName
+		cluster.EdsClusterConfig.ServiceName = makeXdstpClusterLoadAssignmentName(name, namespace, authority, port)
 	}
 
 	switch policy {

--- a/xds/utils.go
+++ b/xds/utils.go
@@ -52,6 +52,10 @@ func makeXdstpClusterName(name, namespace, authority string, port int32) string 
 	return fmt.Sprintf("xdstp://%s/envoy.config.cluster.v3.Cluster/%s", authority, makeClusterName(name, namespace, port))
 }
 
+func makeXdstpClusterLoadAssignmentName(name, namespace, authority string, port int32) string {
+	return fmt.Sprintf("xdstp://%s/envoy.config.endpoint.v3.ClusterLoadAssignment/%s", authority, makeClusterName(name, namespace, port))
+}
+
 // xdstp listener name based on:
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#config-listener-v3-listener
 func makeXdstpListenerName(name, namespace, authority string, port int32) string {


### PR DESCRIPTION
We carelessly used Cluster names for ClusterLoadAssignment resources as well for convenience in code. NodeJS client is doing verification on resource names and fails when experimental federation feature is enabled. This change should fix the naming inconsistency for ClusterLoadAssignment resources when authorities are used.